### PR TITLE
Fix comma in comments, preserve "" on the comment column.

### DIFF
--- a/dmriqcpy/template/index.html
+++ b/dmriqcpy/template/index.html
@@ -263,6 +263,13 @@
                     }
                 },
                 {
+                    extend: 'csv',
+                    fieldSeparator: '\t',
+                    extension: '.tsv',
+                    text: 'Export to .tsv',
+                    filename: 'Quality Control data'
+                },
+                {
                     extend: 'pdf',
                     text: 'Export to .pdf',
                     filename: "Quality Control data"

--- a/dmriqcpy/template/index.html
+++ b/dmriqcpy/template/index.html
@@ -250,7 +250,16 @@
                     text: 'Export to .csv',
                     filename: "Quality Control data",
                     customize: function (csv) {
-                        return csv.split("\"").join("");
+                        var csv = csv.split("\n");
+                        var header = csv[0].split("\"").join("");
+                        var data = csv.slice(1, -1).map(line => {
+                            var fields = line.split("\",\"");
+                            fields[0] = fields[0].replace("\"", "");
+                            last = fields.length - 1;
+                            fields[last] = "\"" + fields[last];
+                            return fields.join(",");
+                        })
+                        return [header].concat(data).join("\n");
                     }
                 },
                 {


### PR DESCRIPTION
There is a bug if we use `,` in the comment column.
With this fix the `,` can be used without issues.